### PR TITLE
Fix duplication of OBF Update talk slot.

### DIFF
--- a/2014/program/BOSC2014_program.tex
+++ b/2014/program/BOSC2014_program.tex
@@ -300,6 +300,7 @@ Time & Title & Author/Notes \\
 11:21-11:39 & New Frontiers of Genome Assembly with SPAdes 3.1 & Andrey Prjibelski\\
 11:39-11:57 & SigSeeker: An Ensemble for Analysis of Epigenetic Data & Jens Lichtenberg\\
 11:57-12:15 & Galaxy as an Extensible Job Execution Platform & John Chilton\\
+\hline
 12:15-12:30 & Open Bioinformatics Foundation (OBF) Update & Hilmar Lapp\\
 \hline
 \textbf{12:30-13:30} & \textbf{Lunch} &\\
@@ -362,9 +363,8 @@ Abstracts follow later in this document.
 \hline
 Time & Title & Author/Notes \\
 \hline
-8:45-8:50 & Announcements & \\
-8:50-9:00 & Codefest 2014 Report & Brad Chapman\\
-9:00-9:15 & Open Bioinformatics Foundation (OBF) update & Hilmar Lapp\\
+8:55-9:00 & Announcements & \\
+9:00-9:15 & Codefest 2014 Report & Brad Chapman\\
 9:15-10:15 & \textbf{Keynote}: Biomedical Research as an Open Digital Enterprise & Philip Bourne\\
 \hline
 \textbf{10:15-10:45} & \textbf{Coffee Break} & \\


### PR DESCRIPTION
This fix would be presuming that the OBF President's Update is indeed now taking place on the first day, and not the morning of the second day. If it has been moved back to the morning of the second day, the entry on the first day needs to be removed instead (and then reject this PR).
